### PR TITLE
use better defaults in docker container for test image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,12 @@ RUN CGO_ENABLED=0 go build -v -o /yakapi .
 # TODO: scratch is probably too restrictive
 FROM scratch
 COPY --from=0 /yakapi /yakapi
+COPY testdata/mars.jpeg /var/mars.jpeg
 
 ENV YAKAPI_PORT=8080
 ENV YAKAPI_NAME="Yak Bot"
 ENV YAKAPI_PROJECT_URL="https://github.com/The-Yak-Collective/yakrover"
 ENV YAKAPI_ADAPTER_MOTOR="echo"
+ENV YAKAPI_CAM_CAPTURE_PATH="/var/mars.jpeg"
 
 CMD ["/yakapi"]

--- a/README.md
+++ b/README.md
@@ -64,10 +64,6 @@ $ docker pull docker pull ghcr.io/the-yak-collective/yakapi:latest
 $ docker run --rm \
   -p 80:8080 \
   -e YAKAPI_NAME="My Rover" \
-  -e YAKAPI_MOTOR_ADAPTER="/var/motor/motor.py" \
-  -v /var/motor:/var/motor \
-  -e YAKAPI_CAM_CAPTURE_PATH="/var/cam/capture.jpeg" \
-  -v /var/cam:/var/cam \
  ghcr.io/the-yak-collective/yakapi:latest
 ...
 ```
@@ -106,4 +102,8 @@ This service translates commands into motor settings.
 
 ### cam
 
-The camera component can current serve an image if placed in a configured path.
+The camera component can serve an image if placed in the path configured by
+`YAKAPI_CAM_CAPTURE_PATH`.
+
+In development, simply visit http://localhost:8080/v1/cam/capture in a browser
+to see your "Rover"'s view of Mars.


### PR DESCRIPTION
This packages the test image into the docker image.

If using the docker image to run locally, visiting /v1/cam/capture will now work out of the box.