### PR TITLE
replace CI implementation by off-loading commands to a script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY --from=0 /yakapi /yakapi
 ENV YAKAPI_PORT=8080
 ENV YAKAPI_NAME="Yak Bot"
 ENV YAKAPI_PROJECT_URL="https://github.com/The-Yak-Collective/yakrover"
-ENV YAKAPI_ADAPTER_MOTOR="echo"
+ENV YAKAPI_CI_ADAPTER="cat"
 
 CMD ["/yakapi"]

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Configuration is primarily through environment variables
 * `YAKAPI_PORT` [default `8080`] port for api server to listen on
 * `YAKAPI_NAME` [default `YakBot`] name for rover 
 * `YAKAPI_PROJECT_URL` [default `https://github.com/The-Yak-Collective/yakrover`] URL for more information
-* `YAKAPI_ADAPTER_MOTOR` [default `echo`] command to be executed to interact with motors
+* `YAKAPI_CI_ADAPTER` [default `cat`] command to be executed for running commands)
 * `YAKAPI_CAM_CAPTURE_PATH` path to image for camera.
 
 ## Components
@@ -102,7 +102,20 @@ yakapi_processed_ops_total 0
 
 ### ci (command injection)
 
-This service translates commands into motor settings. 
+This service injects commands into the Rover provided CI Adapter
+(YAKAPI_CI_ADAPTER). The API simply takes any input in the request body and
+forwards it to the configured adapter. 
+
+In development, the `cat` command is configured resulting in output like this:
+
+```ShellSession
+$ echo "hi there" | script/ci
+{"result":"ok","output":"hi there\n"}
+```
+
+Rover operators should configure yakapi with an executable that will interpret
+the commands appropriately for the platform. For example, a python script might
+translate commands into motor velocities.
 
 ### cam
 

--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -16,6 +16,9 @@ func Accept(ctx context.Context, log *zap.SugaredLogger, runner string, r io.Rea
 	cmd.Stderr = os.Stderr
 	// put stdout in a buffer and log it
 	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", fmt.Errorf("failed to create pipe: %w", err)
+	}
 
 	log.Infow("running ci adapter", "runner", runner)
 

--- a/internal/ci/ci.go
+++ b/internal/ci/ci.go
@@ -2,189 +2,39 @@ package ci
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
-	"strconv"
-	"strings"
-	"time"
+
+	"go.uber.org/zap"
 )
 
-func Accept(ctx context.Context, cmd string) error {
-	if cmd == "" {
-		return errors.New("empty command")
-	}
-
-	f := strings.Fields(cmd)
-	switch f[0] {
-	case "ping":
-		return nil
-	case "fwd":
-		return doFwd(ctx, f[1:])
-	case "ffwd":
-		return doFfwd(ctx, f[1:])
-	case "bck":
-		return doBck(ctx, f[1:])
-	case "lt":
-		return doLT(ctx, f[1:])
-	case "rt":
-		return doRT(ctx, f[1:])
-	default:
-		return errors.New("unknown command")
-	}
-}
-
-func parseDurationArg(arg string) (time.Duration, error) {
-	durationArg, err := strconv.ParseInt(arg, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse duration: %w", err)
-	}
-
-	duration := time.Duration(durationArg) * time.Millisecond * 10
-
-	return duration, nil
-}
-
-func parseAngleArg(arg string) (time.Duration, error) {
-	angleArg, err := strconv.ParseInt(arg, 10, 64)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse duration: %w", err)
-	}
-
-	duration := time.Duration(spinDurationSecs*(float64(angleArg)/90.0)) * time.Second
-	return duration, nil
-}
-
-func doFwd(ctx context.Context, args []string) error {
-	if len(args) != 1 {
-		return errors.New("invalid arguments")
-	}
-
-	duration, err := parseDurationArg(args[0])
-	if err != nil {
-		return err
-	}
-
-	err = motorAndStop(ctx, -0.75, -0.75, duration)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func doFfwd(ctx context.Context, args []string) error {
-	if len(args) != 1 {
-		return errors.New("invalid arguments")
-	}
-
-	duration, err := parseDurationArg(args[0])
-	if err != nil {
-		return err
-	}
-
-	err = motorAndStop(ctx, -1.0, -1.0, duration)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func doBck(ctx context.Context, args []string) error {
-	if len(args) != 1 {
-		return errors.New("invalid arguments")
-	}
-
-	duration, err := parseDurationArg(args[0])
-	if err != nil {
-		return err
-	}
-
-	err = motorAndStop(ctx, 0.75, 0.75, duration)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-const spinDurationSecs = 2.0
-
-func doRT(ctx context.Context, args []string) error {
-	if len(args) != 1 {
-		return errors.New("invalid arguments")
-	}
-
-	duration, err := parseAngleArg(args[0])
-	if err != nil {
-		return err
-	}
-
-	err = motorAndStop(ctx, -0.75, 0.75, duration)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func doLT(ctx context.Context, args []string) error {
-	if len(args) != 1 {
-		return errors.New("invalid arguments")
-	}
-
-	duration, err := parseAngleArg(args[0])
-	if err != nil {
-		return err
-	}
-
-	err = motorAndStop(ctx, 0.75, -0.75, duration)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func execMotorAdapter(ctx context.Context, args []string) error {
-	name := os.Getenv("YAKAPI_ADAPTER_MOTOR")
-	if name == "" {
-		return errors.New("motor adapter not configured")
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Stdout = os.Stdout
+func Accept(ctx context.Context, log *zap.SugaredLogger, runner string, r io.Reader) (string, error) {
+	cmd := exec.CommandContext(ctx, runner)
+	cmd.Stdin = r
 	cmd.Stderr = os.Stderr
+	// put stdout in a buffer and log it
+	stdout, err := cmd.StdoutPipe()
 
-	err := cmd.Run()
+	log.Infow("running ci adapter", "runner", runner)
+
+	err = cmd.Start()
 	if err != nil {
-		return fmt.Errorf("failed running motor adapter: %w", err)
+		return "", fmt.Errorf("failed to start ci adapter: %w", err)
 	}
 
-	return nil
-}
-
-func motorAndStop(ctx context.Context, throttle1, throttle2 float64, d time.Duration) error {
-	err := execMotorAdapter(ctx,
-		[]string{
-			fmt.Sprintf("motor1:%.2f", throttle1),
-			fmt.Sprintf("motor2:%.2f", throttle2)})
+	output, err := io.ReadAll(stdout)
 	if err != nil {
-		return err
+		return "", fmt.Errorf("failed to read ci adapter output: %w", err)
 	}
 
-	fmt.Printf("sleeping for %.3fs\n", d.Seconds())
-	time.Sleep(d)
-
-	err = execMotorAdapter(ctx, []string{"motor1:0.0", "motor2:0.0"})
+	err = cmd.Wait()
 	if err != nil {
-		return err
+		return "", fmt.Errorf("failed to wait for ci adapter: %w", err)
 	}
 
-	return nil
+	log.Infow("complete", "runner", runner, "exit", cmd.ProcessState.ExitCode(), "output_size", len(output))
+
+	return string(output), nil
 }

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+curl -sL -X POST --data-binary @- --no-buffer http://localhost:8080/v1/ci

--- a/script/server
+++ b/script/server
@@ -5,7 +5,7 @@ script/build
 
 export YAKAPI_NAME="YakAPI (development)"
 export YAKAPI_PROJECT="https://github.com/The-Yak-Collective/yakapi"
-export YAKAPI_MOTOR_ADAPTER="echo"
+export YAKAPI_CI_ADAPTER="cat"
 export YAKAPI_CAM_CAPTURE_PATH="./testdata/mars.jpeg"
 
-./bin/yakapi
+./bin/yakapi-$(go env GOARCH)


### PR DESCRIPTION
This removes some of the command language interpretation that was specific to the Batteries Not Included rover make yakapi a more generic platform.